### PR TITLE
Test calculator using printer double and make calculator work

### DIFF
--- a/lib/calculator.rb
+++ b/lib/calculator.rb
@@ -1,11 +1,18 @@
 require_relative 'printer'
 
 class Calculator
+  
+  attr_reader :printer
+
+  def initialize(printer=Printer.new)
+  	@printer = printer
+  end
+
   def add(a,b)
-    a + b
+    printer.pretty_print(a + b)
   end
 
   def subtract(a,b)
-    a - b
+    printer.pretty_print(a - b)
   end
 end

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -1,4 +1,5 @@
 require 'printer'
+
 describe Printer do
   subject(:printer){ described_class.new }
   it 'produces a pretty string' do

--- a/spec/scripts_spec.rb
+++ b/spec/scripts_spec.rb
@@ -1,12 +1,22 @@
 require 'calculator'
 
 describe Calculator do
-  subject(:calculator){ described_class.new }
+
+  subject(:calculator){ described_class.new(printer) }
+  let(:printer) do 
+  	printer = double("printer")
+  	allow(printer).to receive(:pretty_print)
+  	printer
+  end
+
   it '#add' do
-    expect(calculator.add(1,1)).to eq 2
+  	expect(printer).to receive(:pretty_print).with(2)
+    calculator.add(1,1)
   end
 
   it '#subtract' do
-    expect(calculator.subtract(1,1)).to eq 0
+    expect(printer).to receive(:pretty_print).with(0)
+    calculator.subtract(1,1)
   end
+
 end


### PR DESCRIPTION
Not 100% sure this is dependency injection, but it works...

I've used a double to represent the printer in the test. It gets set to the calculator's @printer attribute when a calculator is initialized. 

Is it a problem that there's no test checking that the @printer is an instance of the Printer class? All the tests pass, but the calculator wouldn't work if you did something like:

calc = Calculator.new(Array.new)
calc.add(1,1)
